### PR TITLE
Bump to 0.18.12-SNAPSHOT

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def version "0.18.11")
+(def version "0.18.12-SNAPSHOT")
 
 (defproject datascript (str version (System/getenv "DATASCRIPT_CLASSIFIER"))
   :description "An implementation of Datomic in-memory database and Datalog query engine in ClojureScript"


### PR DESCRIPTION
0.18.12 版本将 datascript 移植到 arcadia-unity/clojure-clr 。