### PR TITLE
在 CLR 平台实现 arrays，并补充测试用例。

### DIFF
--- a/src/datascript/impl/sorted_set/arrays.cljc
+++ b/src/datascript/impl/sorted_set/arrays.cljc
@@ -1,0 +1,88 @@
+(ns ^:no-doc datascript.impl.sorted-set.arrays
+    (:refer-clojure :exclude
+                    [make-array into-array array amap aget aset alength array? aclone])
+    #?(:cljr (:import [System Array])))
+
+#?(:cljr
+   (defn make-array ^{:tag "System.Object[]"} [size]
+       (clojure.core/make-array System.Object size)))
+
+#?(:cljr
+   (defn into-array ^{:tag "System.Object[]"} [aseq]
+       (clojure.core/into-array System.Object aseq)))
+
+#?(:cljr
+   (defmacro aget [arr i]
+       `(clojure.lang.RT/aget ~(vary-meta arr assoc :tag "System.Object") (int ~i))))
+
+#?(:cljr
+   (defmacro alength [arr]
+       `(clojure.lang.RT/alength ~(vary-meta arr assoc :tag "System.Object"))))
+
+#?(:cljr
+   (defmacro aset [arr i v]
+       `(clojure.lang.RT/aset ~(vary-meta arr assoc :tag "System.Object") (int ~i) ~v)))
+
+#?(:cljr
+   (defmacro array [& args]
+       (let [len (count args)]
+           (if (zero? len)
+               'clojure.lang.RT/EMPTY_ARRAY
+               `(let [arr# (clojure.core/make-array System.Object ~len)]
+                 (doto ^{:tag "System.Object"} arr#
+                       ~@(map #(list 'aset % (nth args %)) (range len))))))))
+
+#?(:cljr
+   (defmacro acopy [from from-start from-end to to-start]
+       `(let [l# (- ~from-end ~from-start)]
+         (when (pos? l#)
+             (Array/Copy ~from ~from-start ~to ~to-start l#)))))
+
+#?(:cljr
+   (defn aclone [from]
+       (let [length (alength from)
+             to     (make-array length)]
+           (acopy from 0 length to 0)
+           to)))
+
+#?(:cljr
+   (defn aconcat [a b]
+       (let [al  (alength a)
+             bl  (alength b)
+             res (make-array (+ al bl))]
+           (.CopyTo a res 0)
+           (.CopyTo b res al)
+           res)))
+
+#?(:cljr
+   (defn amap
+       ([f arr]
+        (amap f System.Object arr))
+       ([f type arr]
+        (let [res (clojure.core/make-array type (alength arr))]
+            (dotimes [i (alength arr)]
+                (aset res i (f (aget arr i))))
+            res))))
+
+#?(:cljr
+   (defn asort [arr cmp]
+       (doto arr (Array/Sort cmp))))
+
+#?(:cljr
+   (defn array? [^Object x]
+       (instance? System.Array x)))
+
+#?(:cljr
+   (defmacro alast [arr]
+       `(let [arr# ~arr]
+         (aget arr# (dec (alength arr#))))))
+
+#?(:cljr
+   (defmacro half [x]
+       `(unsigned-bit-shift-right ~x 1)))
+
+#?(:cljr
+   (def array-type
+       (memoize
+        (fn [type]
+            (clojure.core/type (clojure.core/make-array type 0))))))

--- a/test/datascript/test/impl/sorted_set/arrays.cljc
+++ b/test/datascript/test/impl/sorted_set/arrays.cljc
@@ -1,0 +1,75 @@
+(ns datascript.test.impl.sorted-set.arrays
+    (:require
+        [clojure.test :as t
+         :refer           [is are deftest testing]]
+        [datascript.impl.sorted-set.arrays :as arrays]))
+
+(deftest arrays-all-tests
+    (testing "read only test"
+             (is
+              (= [nil nil nil]
+                 (arrays/make-array 3)))
+
+             (let [arr (arrays/into-array [1 2 3])]
+                 (is
+                  (= [1 2 3]
+                     arr))
+
+                 (is
+                  (= 3
+                     (arrays/aget arr 2)))
+
+                 (is
+                  (= 3
+                     (arrays/alength arr)))
+
+                 (is
+                  (= [1 2 3]
+                     (arrays/array 1 2 3)))
+
+                 (is
+                  (= [nil 1 2]
+                     (arrays/acopy arr 0 2 (arrays/make-array 3) 1)))
+
+                 (is
+                  (= [1 2 3]
+                     (arrays/aclone arr)))
+
+                 (is
+                  (= [1 2 3 1 2 3]
+                     (arrays/aconcat arr arr)))
+
+                 (is
+                  (= ["1" "2" "3"]
+                     (arrays/amap str System.String arr)))
+
+                 (is
+                  (= true
+                     (arrays/array? arr)))
+
+                 (is
+                  (= 3
+                     (arrays/alast arr))))
+
+             (is
+              (= 2
+                 (arrays/half 5))))
+
+    (testing "modify test"
+
+             ;; aset test
+             (let [arr      (arrays/into-array [11 12 13])
+                   aset-ret (arrays/aset arr 2 4)]
+                 (is
+                  (= 4
+                     aset-ret))
+
+                 (is
+                  (= [11 12 4]
+                     arr)))
+
+             ;; asort test
+             (let [arr      (arrays/into-array [11 12 13])]
+                 (is
+                  (= [13 12 11]
+                     (arrays/asort arr >))))))


### PR DESCRIPTION
* 原有的 arrays 实现在 https://github.com/tonsky/persistent-sorted-set/blob/master/src-clojure/me/tonsky/persistent_sorted_set/arrays.cljc ，不支持 CLR。
* 本 PR 是将 datascirpt 库移植到 CLR 的第1步。