### PR TITLE
Impl rslice function & Reversible interface

### DIFF
--- a/src/datascript/impl/persistent_sorted_set.cljc
+++ b/src/datascript/impl/persistent_sorted_set.cljc
@@ -736,13 +736,15 @@
     ;(count [this] (.count set))
     ;(count [this] (throw (ex-info "Noimplement: clojure.lang.ISeq.count" {})))
     ;(empty [this] (throw (ex-info "Noimplement: clojure.lang.ISeq.empty" {})))
-    ;(equiv [this x] (throw (ex-info "Noimplement: clojure.lang.ISeq.equiv" {})))
-
-    clojure.lang.Counted
-    (count [this] (-count set))
+    (equiv [this x] (-equiv this x))
 
     clojure.lang.Seqable
-    (seq [this] (-seq this)))
+    (seq [this] (-seq this))
+    
+    clojure.lang.Sequential
+
+    clojure.lang.Reversible
+    (rseq [this] (-rseq this)))
 
 (defn iter [set left right]
     (Iter. set left right (keys-for set left) (path-get left 0)))
@@ -793,7 +795,26 @@
     IPrintWithWriter
     (-pr-writer [this writer opts]
         ;        (pr-sequential-writer writer pr-writer "(" " " ")" opts (seq this))
-        ))
+        )
+
+
+    clojure.lang.ISeq
+    (first [this] (-first this))
+    (next [this] (-next this))
+    (more [this] (-rest this))
+    ;(cons [this x] (throw (ex-info "NoImplement: clojure.lang.ISeq.cons" {})))
+    ;(count [this] (.count set))
+    ;(count [this] (throw (ex-info "Noimplement: clojure.lang.ISeq.count" {})))
+    ;(empty [this] (throw (ex-info "Noimplement: clojure.lang.ISeq.empty" {})))
+    (equiv [this x] (-equiv this x))
+
+    clojure.lang.Seqable
+    (seq [this] (-seq this))
+
+    clojure.lang.Sequential
+
+    clojure.lang.Reversible
+    (rseq [this] (-rseq this)))
 
 (defn riter [set left right]
     (ReverseIter. set left right (keys-for set right) (path-get right 0)))

--- a/test/datascript/test/impl/sorted_set.cljc
+++ b/test/datascript/test/impl/sorted_set.cljc
@@ -36,7 +36,6 @@
 (def ds [[:a :b] [:b :x] [:b :q] [:a :d]])
 (def e1 (reduce conj e0 ds))
 
-(t/run-tests)
 
 
 (deftest semantic-test-btset-by
@@ -59,44 +58,41 @@
     (range from (inc to))
     (range from (dec to) -1)))
 
-
-(into (set/sorted-set) (shuffle (irange 0 32)))
-
 (deftest test-slice
   (dotimes [i iters]
     (testing "straight 3 layers"
       (let [s (into (set/sorted-set) (shuffle (irange 0 5000)))]
         (are [from to expected] (= expected (set/slice s from to))
-          #?@(:cljr [
+          #?@(:clj [
                nil    nil    (irange 0 5000)
                
-;               -1     nil    (irange 0 5000)
-;               0      nil    (irange 0 5000)
-;               0.5    nil    (irange 1 5000)
-;               1      nil    (irange 1 5000)
-;               4999   nil    [4999 5000]
-;               4999.5 nil    [5000]
-;               5000   nil    [5000]
-;               5000.5 nil    nil
-               
-;               nil    -1     nil
-;               nil    0      [0]
-;               nil    0.5    [0]
-;               nil    1      [0 1]
-;               nil    4999   (irange 0 4999)
-;               nil    4999.5 (irange 0 4999)
-;               nil    5000   (irange 0 5000)
-;               nil    5001   (irange 0 5000)
+               -1     nil    (irange 0 5000)
+               0      nil    (irange 0 5000)
+               0.5    nil    (irange 1 5000)
+               1      nil    (irange 1 5000)
+               4999   nil    [4999 5000]
+               4999.5 nil    [5000]
+               5000   nil    [5000]
+               5000.5 nil    nil
+
+               nil    -1     nil
+               nil    0      [0]
+               nil    0.5    [0]
+               nil    1      [0 1]
+               nil    4999   (irange 0 4999)
+               nil    4999.5 (irange 0 4999)
+               nil    5000   (irange 0 5000)
+               nil    5001   (irange 0 5000)
           ])
 
-;          -2     -1     nil
-;          -1     5001   (irange 0 5000)
-;          0      5000   (irange 0 5000)
-;          0.5    4999.5 (irange 1 4999)
-;          2499.5 2500.5 [2500]
-;          2500   2500   [2500]
-;          2500.1 2500.9 nil
-;          5001   5002   nil
+          -2     -1     nil
+          -1     5001   (irange 0 5000)
+          0      5000   (irange 0 5000)
+          0.5    4999.5 (irange 1 4999)
+          2499.5 2500.5 [2500]
+          2500   2500   [2500]
+          2500.1 2500.9 nil
+          5001   5002   nil
              )))
 
     (testing "straight 1 layer, leaf == root"


### PR DESCRIPTION
* 实现 rslice 函数和 Reversible 接口，跑通原有测试用例。
* 打开注释掉的测试，原 clj 平台的测试不予支持。