### PR TITLE
Pass all db test cases

### DIFF
--- a/src/datascript/core.cljc
+++ b/src/datascript/core.cljc
@@ -699,9 +699,7 @@
   ([]
     (squuid #?(:clj  (System/currentTimeMillis)
                :cljs (.getTime (js/Date.))
-               :cljr (long (/ (- (.Ticks DateTime/Now)
-                                 (.Ticks (DateTime. 1970 1 1 0 0 0 0)))
-                              10000)))))
+               :cljr (long (.TotalMilliseconds (.Subtract DateTime/Now (DateTime. 1970 1 1 0 0 0 0 DateTimeKind/Utc)))))))
   ([msec]
   #?(:clj
       (let [uuid     (UUID/randomUUID)

--- a/src/datascript/core.cljc
+++ b/src/datascript/core.cljc
@@ -698,7 +698,10 @@
    Consist of 64 bits of current UNIX timestamp (in seconds) and 64 random bits (2^64 different unique values per second)."
   ([]
     (squuid #?(:clj  (System/currentTimeMillis)
-               :cljs (.getTime (js/Date.)))))
+               :cljs (.getTime (js/Date.))
+               :cljr (long (/ (- (.Ticks DateTime/Now)
+                                 (.Ticks (DateTime. 1970 1 1 0 0 0 0)))
+                              10000)))))
   ([msec]
   #?(:clj
       (let [uuid     (UUID/randomUUID)
@@ -718,7 +721,14 @@
            "-" (-> (rand-bits 16) (bit-and 0x3FFF) (bit-or 0x8000) (to-hex-string 4))
            "-" (-> (rand-bits 16) (to-hex-string 4))
                (-> (rand-bits 16) (to-hex-string 4))
-               (-> (rand-bits 16) (to-hex-string 4)))))))
+               (-> (rand-bits 16) (to-hex-string 4))))
+     :cljr
+      (let [low-str (-> (Guid/NewGuid)
+                        (str)
+                        (clojure.string/replace "-" "")
+                        (subs 8))
+            time    (int (/ msec 1000))]
+          (Guid/Parse (str (format "%08x" time) low-str))))))
 
 (defn squuid-time-millis
   "Returns time that was used in [[squuid]] call, in milliseconds, rounded to the closest second."
@@ -728,4 +738,7 @@
               (* 1000))
      :cljs (-> (subs (str uuid) 0 8)
                (js/parseInt 16)
+               (* 1000))
+     :cljr (-> (subs (str uuid) 0 8)
+               (Int64/Parse System.Globalization.NumberStyles/HexNumber)
                (* 1000))))

--- a/src/datascript/db.cljc
+++ b/src/datascript/db.cljc
@@ -565,8 +565,7 @@
        ITransientCollection (-conj! [db key] (throw (ex-info "datascript.DB/conj! is not supported" {})))
                             (-persistent! [db] (db-persistent! db))
        #?@(:cljr [clojure.lang.IHashEq (hasheq [db] (-hash db))
-                  clojure.lang.IEditableCollection (asTransient [db] #_(throw (ex-info "unsupported astransient" {}))
-                                                                (-as-transient db))
+                  clojure.lang.IEditableCollection (asTransient [db] (-as-transient db))
                   clojure.lang.ITransientCollection 
                   (conj [db key] (-conj! db key))
                   (persistent [db] (-persistent! db))])]

--- a/src/datascript/impl/persistent_sorted_set.cljc
+++ b/src/datascript/impl/persistent_sorted_set.cljc
@@ -448,7 +448,14 @@
 
     clojure.lang.IPersistentSet
     (disjoin [this key] (-disjoin this key))
-    (contains [this key] (-lookup this key)))
+    (contains [this key] (-lookup this key))
+    
+    clojure.lang.IEditableCollection
+    (asTransient [this] (-as-transient this))
+    
+    clojure.lang.ITransientCollection
+    (conj [this x] (-conj! this x))
+    (persistent [this] (-persistent! this)))
 
 (defn- keys-for [set path]
     (loop [level (.-shift set)

--- a/test/datascript/test/db.cljc
+++ b/test/datascript/test/db.cljc
@@ -21,9 +21,11 @@
       :cljr [clojure.lang.IHashEq (hasheq [hb] 0xBEEF)]))
 
 (deftest test-defrecord-updatable
-  (is (= 0xBEEF (-> (map->HashBeef {:x :ignored}) hash))))
-
-
+  (is (= 0xBEEF 
+         (-> #?(:clj  (map->HashBeef {:x :ignored})
+                :cljs (map->HashBeef {:x :ignored})
+                :cljr (HashBeef. :ignored))
+             hash))))
 
 ;; whitebox test to confirm that hash cache caches
 (deftest test-db-hash-cache

--- a/test/datascript/test/db.cljc
+++ b/test/datascript/test/db.cljc
@@ -22,10 +22,7 @@
 
 (deftest test-defrecord-updatable
   (is (= 0xBEEF 
-         (-> #?(:clj  (map->HashBeef {:x :ignored})
-                :cljs (map->HashBeef {:x :ignored})
-                :cljr (HashBeef. :ignored))
-             hash))))
+         (hash (map->HashBeef {:x :ignored})))))
 
 ;; whitebox test to confirm that hash cache caches
 (deftest test-db-hash-cache

--- a/test/datascript/test/db.cljc
+++ b/test/datascript/test/db.cljc
@@ -34,9 +34,7 @@
 (defn- now []
   #?(:clj  (System/currentTimeMillis)
      :cljs (.getTime (js/Date.))
-     :cljr (long (/ (- (.Ticks DateTime/Now)
-                       (.Ticks (DateTime. 1970 1 1 0 0 0 0)))
-                    10000))))
+     :cljr (long (.TotalMilliseconds (.Subtract DateTime/Now (DateTime. 1970 1 1 0 0 0 0 DateTimeKind/Utc))))))
 
 (deftest test-uuid
   (let [now-ms (loop []


### PR DESCRIPTION
* 恢复对 DB 的定义，底层仍然由 defrecord 来创建。
* 补充 sorted-set 未实现的接口。
* 通过 db 全部测试用例。